### PR TITLE
change UI and fix errors for bookmarks

### DIFF
--- a/bookmarks.css
+++ b/bookmarks.css
@@ -27,19 +27,27 @@
 }
 
 /* Bookmarks - for viewing */
-#bookmarksOutput {
-  width: 200px;
-}
-
 #bookmarksOutput > span {
   display: flex;
+  align-items: center;
 }
 
 #bookmarks_toggler {
   border: 1px solid;
-  font-size: 18px;
+  font-size: 16px;
   padding: 0 10px;
+  margin: 0 10px 0 20px;
+  opacity: 0.7;
 }
+
+#bookmarks_toggler:hover {
+  opacity: 1;
+}
+
 #bookmarks_toggler.dark:hover {
   color: white;
+}
+
+.deleteBtn:hover {
+  color: red !important;
 }

--- a/bookmarks.js
+++ b/bookmarks.js
@@ -68,7 +68,7 @@ function fetchBookmarks() {
 
         bookmarksOutput.innerHTML += '<span>' +
             '<a href="' + URL + '" class="dropdown-item" target="_blank" >' + name + '</a>' +
-            '<a onclick="deleteBookmark(\'' + URL + '\')" class="btn " href="#"> X </a>' +
+            '<a onclick="deleteBookmark(\'' + URL + '\')" class="btn deleteBtn" href="#">&times;</a>' +
             '</span>';
     }
 }

--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
               data-bs-toggle="dropdown" aria-expanded="false">Bookmarks</a>
             <div class="dropdown-menu bookmarks light_dark" aria-labelledby="navbarDropdownMenuLink"
               id="bookmarksOutput"></div>
-            <button class="btn light_dark" id="bookmarks_toggler">+ Add</button>
+            <button class="btn light_dark" id="bookmarks_toggler">&plus; Add</button>
 
           </div>
 

--- a/style.css
+++ b/style.css
@@ -236,11 +236,19 @@ img:hover {
 }
 
 .bookmarks.light a {
-  color: black;
+  color: rgba(60, 60, 60, 0.75);
+}
+
+.bookmarks.light a:hover {
+  color: #000;
 }
 
 .bookmarks.dark a {
-  color: white;
+  color: rgba(196, 196, 196, 0.75);
+}
+
+.bookmarks.dark a:hover {
+  color: #fff;
 }
 
 .bookmarks.light div {
@@ -254,8 +262,8 @@ img:hover {
 .dropdown .bookmarks {
   /* display: block; */
   /* for dropdown on hover */
-  top: 110%;
-  left: -150px;
+  top: 120%;
+  left: -10px;
 }
 
 /* footer */


### PR DESCRIPTION
### UI changes:
Change colors for bookmark items on hover and non-hover state
- light theme
  - non-hover: `{color: rgba(60, 60, 60, 0.75);}`
  - hover: `{color: #000;}`
- dark theme
  - non-hover: `{color: rgba(196, 196, 196, 0.75);}`
  - hover: `{color: #fff;}`
  
### Other Updates
- Delete btn `Color: red` on hover
- Delete btn `&times;` instead of `X`
- Add btn `&plus;` instead of `+`
- Align bookmarks vertically in flex-box
- ++padding in `add bookmarks` and `view bookmarks` option


